### PR TITLE
fix: add consistency check after creating actions variables

### DIFF
--- a/github/resource_github_actions_variable.go
+++ b/github/resource_github_actions_variable.go
@@ -2,10 +2,13 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/google/go-github/v74/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -58,8 +61,9 @@ func resourceGithubActionsVariableCreate(d *schema.ResourceData, meta any) error
 	ctx := context.Background()
 
 	repo := d.Get("repository").(string)
+	variableName := d.Get("variable_name").(string)
 	variable := &github.ActionsVariable{
-		Name:  d.Get("variable_name").(string),
+		Name:  variableName,
 		Value: d.Get("value").(string),
 	}
 
@@ -68,7 +72,32 @@ func resourceGithubActionsVariableCreate(d *schema.ResourceData, meta any) error
 		return err
 	}
 
-	d.SetId(buildTwoPartID(repo, d.Get("variable_name").(string)))
+	d.SetId(buildTwoPartID(repo, variableName))
+
+	createStateConf := &retry.StateChangeConf{
+		Pending: []string{"waiting"},
+		Target:  []string{"exists"},
+		Refresh: func() (interface{}, string, error) {
+			variableObj, _, err := client.Actions.GetRepoVariable(ctx, owner, repo, variableName)
+			if err != nil {
+				if ghErr, ok := err.(*github.ErrorResponse); ok {
+					if ghErr.Response.StatusCode == http.StatusNotFound {
+						return nil, "waiting", nil
+					}
+				}
+				return nil, "", err
+			}
+			return variableObj, "exists", nil
+		},
+		Timeout:    1 * time.Minute,
+		Delay:      1 * time.Second,
+		MinTimeout: 2 * time.Second,
+	}
+
+	if _, err := createStateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for variable %s to be consistent: %s", variableName, err)
+	}
+
 	return resourceGithubActionsVariableRead(d, meta)
 }
 

--- a/github/resource_github_actions_variable.go
+++ b/github/resource_github_actions_variable.go
@@ -2,13 +2,13 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"time"
 
 	"github.com/google/go-github/v74/github"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -74,28 +74,8 @@ func resourceGithubActionsVariableCreate(d *schema.ResourceData, meta any) error
 
 	d.SetId(buildTwoPartID(repo, variableName))
 
-	createStateConf := &retry.StateChangeConf{
-		Pending: []string{"waiting"},
-		Target:  []string{"exists"},
-		Refresh: func() (interface{}, string, error) {
-			variableObj, _, err := client.Actions.GetRepoVariable(ctx, owner, repo, variableName)
-			if err != nil {
-				if ghErr, ok := err.(*github.ErrorResponse); ok {
-					if ghErr.Response.StatusCode == http.StatusNotFound {
-						return nil, "waiting", nil
-					}
-				}
-				return nil, "", err
-			}
-			return variableObj, "exists", nil
-		},
-		Timeout:    1 * time.Minute,
-		Delay:      1 * time.Second,
-		MinTimeout: 2 * time.Second,
-	}
-
-	if _, err := createStateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("error waiting for variable %s to be consistent: %s", variableName, err)
+	if err := waitForVariableConsistency(ctx, client, owner, repo, variableName); err != nil {
+		return err
 	}
 
 	return resourceGithubActionsVariableRead(d, meta)
@@ -176,4 +156,51 @@ func resourceGithubActionsVariableDelete(d *schema.ResourceData, meta any) error
 	_, err = client.Actions.DeleteRepoVariable(ctx, orgName, repoName, variableName)
 
 	return err
+}
+
+func waitForVariableConsistency(
+	ctx context.Context,
+	client *github.Client,
+	owner, repo, variableName string,
+) error {
+	// Derived context with overall timeout for the wait.
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	// Initial delay to match previous behaviour.
+	select {
+	case <-ctxWithTimeout.Done():
+		return fmt.Errorf("context done before waiting for variable %s: %w", variableName, ctxWithTimeout.Err())
+	case <-time.After(time.Second):
+	}
+
+	backoff := time.Second
+	maxBackoff := 10 * time.Second
+
+	for {
+		_, _, err := client.Actions.GetRepoVariable(ctxWithTimeout, owner, repo, variableName)
+		if err == nil {
+			return nil
+		}
+
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			// Variable not visible yet, wait with exponential backoff.
+			select {
+			case <-ctxWithTimeout.Done():
+				return fmt.Errorf("timeout waiting for variable %s to be consistent: %w", variableName, ctxWithTimeout.Err())
+			case <-time.After(backoff):
+			}
+
+			// Exponential backoff with cap.
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+
+		// Non-404 error: likely not transient.
+		return fmt.Errorf("error waiting for variable %s to be consistent: %w", variableName, err)
+	}
 }

--- a/github/resource_github_actions_variable_test.go
+++ b/github/resource_github_actions_variable_test.go
@@ -89,6 +89,61 @@ func TestAccGithubActionsVariable(t *testing.T) {
 		})
 	})
 
+	t.Run("creates multiple repository variables without error", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%s"
+			}
+
+			resource "github_actions_variable" "variable1" {
+			  repository       = github_repository.test.name
+			  variable_name    = "test_variable_1"
+			  value  = "value1"
+			}
+
+			resource "github_actions_variable" "variable2" {
+			  repository       = github_repository.test.name
+			  variable_name    = "test_variable_2"
+			  value  = "value2"
+			}
+
+			resource "github_actions_variable" "variable3" {
+			  repository       = github_repository.test.name
+			  variable_name    = "test_variable_3"
+			  value  = "value3"
+			}
+			`, randomID)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr("github_actions_variable.variable1", "value", "value1"),
+							resource.TestCheckResourceAttr("github_actions_variable.variable2", "value", "value2"),
+							resource.TestCheckResourceAttr("github_actions_variable.variable3", "value", "value3"),
+						),
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
 	t.Run("deletes repository variables without error", func(t *testing.T) {
 		config := fmt.Sprintf(`
 				resource "github_repository" "test" {


### PR DESCRIPTION
Ensured newly created repository variables are consistently available by introducing a state check with retries after creation. Improved reliability when creating multiple variables in quick succession, preventing issues caused by eventual consistency in the API.

Resolves #12

----

### Before the change?
Currently in nexthink/oss github provider version 7.0.3, when creating a repository with multiple github actions variables, or adding new github actions variables to a repository, terraform apply fails with the `Provider produced inconsistent result after apply` error. 

* 

### After the change?
This PR introduces a retry mechanism in the `resourceGithubActionsVariableCreate` function to wait for the GitHub Actions variable to become visible (eventual consistency) before returning. With this change, `terraform apply` completes without errors.

* 

### Pull request checklist
- [v] Tests for the changes have been added (for bug fixes / features)
- [v] Docs have been reviewed and added / updated if needed (for bug fixes / features)

NOTE: 
- contribution guide mentions that only user-facing functionality changes should be reflected. In this case, the change is not user-facing.
- I noticed test failures on the `main` branch. Most of them are caused by GitHub automatically enabling vulnerability alerts on public repositories, which leads to state drift and hence test failures. I believe a separate issue is needed to address this.

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [  ] Yes
- [v] No

----

