### PR TITLE
feat: remove automatic copilot review for PR

### DIFF
--- a/docs/resources/organization_ruleset.md
+++ b/docs/resources/organization_ruleset.md
@@ -156,7 +156,6 @@ Optional:
 - `allow_merge_commit` (Boolean) Whether users can use the web UI to merge pull requests with a merge commit. Defaults to `true`.
 - `allow_rebase_merge` (Boolean) Whether users can use the web UI to rebase merge pull requests. Defaults to `true`.
 - `allow_squash_merge` (Boolean) Whether users can use the web UI to squash merge pull requests. Defaults to `true`.
-- `automatic_copilot_code_review_enabled` (Boolean) Enable GitHub Copilot code review automation. Defaults to `false`.
 - `dismiss_stale_reviews_on_push` (Boolean) New, reviewable commits pushed will dismiss previous pull request review approvals. Defaults to `false`.
 - `require_code_owner_review` (Boolean) Require an approving review in pull requests that modify files that have a designated code owner. Defaults to `false`.
 - `require_last_push_approval` (Boolean) Whether the most recent reviewable push must be approved by someone other than the person who pushed it. Defaults to `false`.

--- a/docs/resources/repository_ruleset.md
+++ b/docs/resources/repository_ruleset.md
@@ -178,7 +178,6 @@ Optional:
 - `allow_merge_commit` (Boolean) Whether users can use the web UI to merge pull requests with a merge commit. Defaults to `true`.
 - `allow_rebase_merge` (Boolean) Whether users can use the web UI to rebase merge pull requests. Defaults to `true`.
 - `allow_squash_merge` (Boolean) Whether users can use the web UI to squash merge pull requests. Defaults to `true`.
-- `automatic_copilot_code_review_enabled` (Boolean) Enable GitHub Copilot code review automation. Defaults to `false`.
 - `dismiss_stale_reviews_on_push` (Boolean) New, reviewable commits pushed will dismiss previous pull request review approvals. Defaults to `false`.
 - `require_code_owner_review` (Boolean) Require an approving review in pull requests that modify files that have a designated code owner. Defaults to `false`.
 - `require_last_push_approval` (Boolean) Whether the most recent reviewable push must be approved by someone other than the person who pushed it. Defaults to `false`.

--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -244,12 +244,6 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 										Default:     true,
 										Description: "Whether users can use the web UI to rebase merge pull requests. Defaults to `true`.",
 									},
-									"automatic_copilot_code_review_enabled": {
-										Type:        schema.TypeBool,
-										Optional:    true,
-										Default:     false,
-										Description: "Enable GitHub Copilot code review automation. Defaults to `false`.",
-									},
 								},
 							},
 						},

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -232,12 +232,6 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 										Default:     true,
 										Description: "Whether users can use the web UI to rebase merge pull requests. Defaults to `true`.",
 									},
-									"automatic_copilot_code_review_enabled": {
-										Type:        schema.TypeBool,
-										Optional:    true,
-										Default:     false,
-										Description: "Enable GitHub Copilot code review automation. Defaults to `false`.",
-									},
 								},
 							},
 						},

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -312,11 +312,6 @@ func expandRules(input []any, org bool) *github.RepositoryRulesetRules {
 			RequiredReviewThreadResolution: pullRequestMap["required_review_thread_resolution"].(bool),
 		}
 
-		// Handle optional automatic_copilot_code_review_enabled
-		if copilotReview, exists := pullRequestMap["automatic_copilot_code_review_enabled"]; exists {
-			copilotEnabled := copilotReview.(bool)
-			rules.PullRequest.AutomaticCopilotCodeReviewEnabled = &copilotEnabled
-		}
 	}
 
 	// Merge queue rule
@@ -504,9 +499,6 @@ func flattenRules(rules *github.RepositoryRulesetRules, org bool) []any {
 				rule["allow_rebase_merge"] = true
 			}
 		}
-
-		// Handle optional automatic_copilot_code_review_enabled
-		rule["automatic_copilot_code_review_enabled"] = rules.PullRequest.GetAutomaticCopilotCodeReviewEnabled()
 
 		rulesMap["pull_request"] = []map[string]any{rule}
 	}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `automatic_copilot_code_review_enabled` was part of PR repository ruleset

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `automatic_copilot_code_review_enabled` removed as GitHub API has changed and now it is rules object `copilot_code_review` with different properties. But latest `google/go-github/v80` doesn't have support for it yet.
https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#create-a-repository-ruleset

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

