### PR TITLE
fix(organization_ruleset): make ref_name optional for push rulesets

### DIFF
--- a/docs/resources/organization_ruleset.md
+++ b/docs/resources/organization_ruleset.md
@@ -70,7 +70,7 @@ resource "github_organization_ruleset" "example" {
 ### Optional
 
 - `bypass_actors` (Block List) The actors that can bypass the rules in this ruleset. (see [below for nested schema](#nestedblock--bypass_actors))
-- `conditions` (Block List, Max: 1) Parameters for an organization ruleset condition. `ref_name` is required alongside one of `repository_name`, `repository_id` or `repository_property`. (see [below for nested schema](#nestedblock--conditions))
+- `conditions` (Block List, Max: 1) Parameters for an organization ruleset condition. `ref_name` is required alongside one of `repository_name`, `repository_id` or `repository_property` for branch and tag rulesets. The push rulesets conditions object does not require the ref_name property. (see [below for nested schema](#nestedblock--conditions))
 
 ### Read-Only
 
@@ -299,15 +299,14 @@ Required:
 <a id="nestedblock--conditions"></a>
 ### Nested Schema for `conditions`
 
-Required:
-
-- `ref_name` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--conditions--ref_name))
-
 Optional:
 
+- `ref_name` (Block List, Max: 1) (see [below for nested schema](#nestedblock--conditions--ref_name))
 - `repository_id` (List of Number) The repository IDs that the ruleset applies to. One of these IDs must match for the condition to pass.
 - `repository_name` (Block List, Max: 1) (see [below for nested schema](#nestedblock--conditions--repository_name))
 - `repository_property` (Block List, Max: 1) Condition to target repositories by property. (see [below for nested schema](#nestedblock--conditions--repository_property))
+
+**Note:** For `branch` and `tag` target types, `ref_name` is required alongside one of `repository_name`, `repository_id`, or `repository_property`. For `push` target type, `ref_name` is optional.
 
 <a id="nestedblock--conditions--ref_name"></a>
 ### Nested Schema for `conditions.ref_name`

--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -85,12 +85,12 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Parameters for an organization ruleset condition. `ref_name` is required alongside one of `repository_name`, `repository_id` or `repository_property`.",
+				Description: "Parameters for an organization ruleset condition. `ref_name` is required alongside one of `repository_name`, `repository_id` or `repository_property` for branch and tag rulesets. The push rulesets conditions object does not require the ref_name property.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ref_name": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -673,6 +673,8 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		CustomizeDiff: validateOrganizationRulesetRefName,
 	}
 }
 
@@ -801,4 +803,17 @@ func resourceGithubOrganizationRulesetImport(d *schema.ResourceData, meta any) (
 	d.SetId(strconv.FormatInt(ruleset.GetID(), 10))
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func validateOrganizationRulesetRefName(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	target := d.Get("target").(string)
+
+	// For branch and tag rulesets, ref_name must be set
+	if target == "branch" || target == "tag" {
+		if _, ok := d.GetOk("conditions.0.ref_name"); !ok {
+			return fmt.Errorf("ref_name is required in conditions when target is '%s'", target)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
The GitHub API does not require ref_name for push target rulesets, only for
branch and tag rulesets. Updated schema to make ref_name optional and added
CustomizeDiff validation to ensure ref_name is still required when target is
'branch' or 'tag'.

Ref: https://docs.github.com/en/rest/orgs/rules?apiVersion=2022-11-28#update-an-organization-repository-ruleset"

### After the change?
Added a check for target:tag & target:branch to validate that ref_name is added otherwise fail. 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

