### PR TITLE
fix: resolve inconsistent provider reply errors, add waitForEnvironme…

### DIFF
--- a/github/resource_github_actions_environment_variable.go
+++ b/github/resource_github_actions_environment_variable.go
@@ -2,9 +2,12 @@ package github
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/go-github/v81/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -80,6 +83,11 @@ func resourceGithubActionsEnvironmentVariableCreate(d *schema.ResourceData, meta
 	}
 
 	d.SetId(buildThreePartID(repoName, envName, name))
+
+	if err := waitForEnvironmentVariableConsistency(ctx, client, owner, repoName, escapedEnvName, name); err != nil {
+		return err
+	}
+
 	return resourceGithubActionsEnvironmentVariableRead(d, meta)
 }
 
@@ -155,4 +163,46 @@ func resourceGithubActionsEnvironmentVariableDelete(d *schema.ResourceData, meta
 	_, err = client.Actions.DeleteEnvVariable(ctx, owner, repoName, escapedEnvName, name)
 
 	return err
+}
+
+func waitForEnvironmentVariableConsistency(
+	ctx context.Context,
+	client *github.Client,
+	owner, repoName, escapedEnvName, variableName string,
+) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	select {
+	case <-ctxWithTimeout.Done():
+		return fmt.Errorf("context done before waiting for environment variable %s: %w", variableName, ctxWithTimeout.Err())
+	case <-time.After(time.Second):
+	}
+
+	backoff := time.Second
+	maxBackoff := 10 * time.Second
+
+	for {
+		_, _, err := client.Actions.GetEnvVariable(ctxWithTimeout, owner, repoName, escapedEnvName, variableName)
+		if err == nil {
+			return nil
+		}
+
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			select {
+			case <-ctxWithTimeout.Done():
+				return fmt.Errorf("timeout waiting for environment variable %s to be consistent: %w", variableName, ctxWithTimeout.Err())
+			case <-time.After(backoff):
+			}
+
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+
+		return fmt.Errorf("error waiting for environment variable %s to be consistent: %w", variableName, err)
+	}
 }

--- a/github/resource_github_actions_environment_variable_test.go
+++ b/github/resource_github_actions_environment_variable_test.go
@@ -95,6 +95,69 @@ func TestAccGithubActionsEnvironmentVariable(t *testing.T) {
 		})
 	})
 
+	t.Run("creates multiple environment variables without error", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%s"
+			}
+
+			resource "github_repository_environment" "test" {
+			  repository       = github_repository.test.name
+			  environment      = "environment / test"
+			}
+
+			resource "github_actions_environment_variable" "variable1" {
+			  repository       = github_repository.test.name
+			  environment      = github_repository_environment.test.environment
+			  variable_name    = "test_variable_1"
+			  value            = "value1"
+			}
+
+			resource "github_actions_environment_variable" "variable2" {
+			  repository       = github_repository.test.name
+			  environment      = github_repository_environment.test.environment
+			  variable_name    = "test_variable_2"
+			  value            = "value2"
+			}
+
+			resource "github_actions_environment_variable" "variable3" {
+			  repository       = github_repository.test.name
+			  environment      = github_repository_environment.test.environment
+			  variable_name    = "test_variable_3"
+			  value            = "value3"
+			}
+			`, randomID)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr("github_actions_environment_variable.variable1", "value", "value1"),
+							resource.TestCheckResourceAttr("github_actions_environment_variable.variable2", "value", "value2"),
+							resource.TestCheckResourceAttr("github_actions_environment_variable.variable3", "value", "value3"),
+						),
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
 	t.Run("deletes environment variables without error", func(t *testing.T) {
 		config := fmt.Sprintf(`
 				resource "github_repository" "test" {


### PR DESCRIPTION
…ntVariableConsistency function and enhance environment variable creation tests

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Managing GHA environment variables may result in inconsistent provider reply:
```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to github_actions_environment_variable.example_vars["77"], provider "provider[\"registry.terraform.io/nexthink-oss/github\"]" produced an unexpected new value: Root object was present, but now absent.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

### After the change?

* Creating and changing GHA environment variables is stable and works as expected.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

**Note**: The bugfix is internal consistency handling after create for environment variables, with no schema/argument/import changes, so user-facing resource docs do not need updates.

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

